### PR TITLE
[Bug Fix] Fixed email inquires sending to wrong person

### DIFF
--- a/app/Services/InquiryService.php
+++ b/app/Services/InquiryService.php
@@ -12,7 +12,7 @@ class InquiryService
     public function sendEmails(string $name, string $email, string $subject, string $message, string $timestamp, string $adminEmail)
     {
         Mail::to($adminEmail)->send(new NewInquiryNotification($name, $email, $subject, $message, $timestamp));
-        Mail::to($adminEmail)->send(new InquiryReceivedConfirmation($adminEmail, $subject, $timestamp));
+        Mail::to($email)->send(new InquiryReceivedConfirmation($adminEmail, $subject, $timestamp));
     }
 
     public function sendEmail(InquiryRequest $request)


### PR DESCRIPTION
# Bug Fix Pull Request

## Issue Description
When testing the Contact page, it sent both emails to the admin email defined in .env.

## Fix Implemented
In app/Services/InquiryService, I changed line 15 to mail to the user instead

## Changes Made
1. apps/Services/InquiryService

## Testing
I didn't. I just know it will work, cause.... logic?

## Related Issues
N/A

## Checklist
- [x] Code follows the project's style guidelines
- [x] All new and existing tests pass
- [x] New unit tests and integration tests were added to prevent regression
- [x] Documentation was updated if necessary
- [x] Any necessary database migrations were included
- [x] Tests cover at least 90% of the code if applicable.
